### PR TITLE
Add an optional argument to `proof` command

### DIFF
--- a/itmo-student-thesis/itmo-student-thesis.cls
+++ b/itmo-student-thesis/itmo-student-thesis.cls
@@ -165,7 +165,9 @@
 \newtheorem{notation}[theorem]{Обозначение}
 \newtheorem{condition}[theorem]{Условие}
 \newtheorem{example}[theorem]{Пример}
-\renewcommand{\proof}{\textit{Доказательство}.~}
+\renewcommand{\proof}[1][]{\textit{Доказательство%
+\ifthenelse{\equal{#1}{}}{}{ (#1)}%
+}.~}
 
 %% Листинги, по умолчанию - Java
 


### PR DESCRIPTION
This argument can be helpful to make proof of theorems, declared in the other part of paper
(e.g. the theorem in the main part and the proof is in the appendix).
Usage: 
```
\begin{proof}[of theorem \ref{thm:some-theorem}]
...
\end{proof}
```